### PR TITLE
object-detection - evaluate_images now supports cpu inference

### DIFF
--- a/evaluate_images.py
+++ b/evaluate_images.py
@@ -37,11 +37,14 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     args = parse_args()
 
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logging.info(f'running inference on {device}')
+
     assert args.display or args.save
 
     logging.info(f'loading model from {args.model}')
-    model = MaskRCNN.load(torch.load(args.model))
-    model.cuda().eval()
+    model = MaskRCNN.load(torch.load(args.model, map_location=device))
+    model.to(device).eval()
 
     image_dir = pathlib.Path(args.images)
 
@@ -56,7 +59,7 @@ if __name__ == '__main__':
 
         with torch.no_grad():
             image = F.to_tensor(image)
-            image = image.cuda().unsqueeze(0)
+            image = image.to(device).unsqueeze(0)
 
             results = model(image)
             results = [fn_filter(i) for i in results]

--- a/train.py
+++ b/train.py
@@ -40,6 +40,9 @@ if __name__ == '__main__':
     args = parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
 
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    logging.info(f'running training on {device}')
+
     logging.info('creating dataset and data loaders')
 
     # assert args.train != args.val
@@ -56,16 +59,16 @@ if __name__ == '__main__':
 
     logging.info(f'creating model and optimizer with initial lr of {args.initial_lr}')
     model = MaskRCNN(train_dataset.categories)
-    model = nn.DataParallel(model).cuda()
+    model = nn.DataParallel(model).to(device)
     optimizer = optim.RMSprop(params=[p for p in model.parameters() if p.requires_grad], lr=args.initial_lr)
 
     logging.info('creating trainer and evaluator engines')
-    trainer = create_mask_rcnn_trainer(model=model, optimizer=optimizer, device='cuda', non_blocking=True)
+    trainer = create_mask_rcnn_trainer(model=model, optimizer=optimizer, device=device, non_blocking=True)
     # note(will.brennan) - our evaluator just reports losses! we only want to see if its overfitting!
     evaluator = create_mask_rcnn_evaluator(
         model, metrics={
             'losses': LossAverager(),
-        }, device='cuda', non_blocking=True
+        }, device=device, non_blocking=True
     )
 
     logging.info(f'creating summary writer with tag {args.model_tag}')


### PR DESCRIPTION
In this PR we add support for CPU training and inference; this required minor modifications to `train` and `evaluate_images`. To test this PR, both scripts were run with `CUDA_VISIBLE_DEVICES=-1` so they weren't visible when the application ran. Also checked this by running `nvidia-smi` in another window.